### PR TITLE
Add validation for conf.py entries

### DIFF
--- a/ablog/__init__.py
+++ b/ablog/__init__.py
@@ -51,7 +51,7 @@ def setup(app):
     """Setup ABlog extension."""
 
     for args in CONFIG:
-        app.add_config_value(*args)
+        app.add_config_value(*args[:3])
 
     app.add_directive('post', PostDirective)
     app.add_directive('postlist', PostListDirective)


### PR DESCRIPTION
The ablog conf.py entries are not validated about what values they accept. If the usage is misundestood at all, this can produce weird behavior that appears to be a bug rather than a configuration error. This PR adds a per-value validation function which errors out with
a meaningful error if the values or not as expected. It also adds validation for many of the conf values. 

This PR should specifically fix #35.

**Important**: This PR should only be merged once 2.7 support is dropped, because the string detection is v3.x specific and is not backward compatible with the 2.7 series. 