### PR TITLE
Define an auto-orphan option

### DIFF
--- a/ablog/blog.py
+++ b/ablog/blog.py
@@ -82,6 +82,7 @@ CONFIG = [
     ('post_date_format_short', '%d %B', True),
     ('post_auto_image', 0, True),
     ('post_auto_excerpt', 1, True),
+    ('post_auto_orphan', True, True),
     ('post_redirect_refresh', 5, True),
     ('post_always_section', False, True),
 

--- a/ablog/post.py
+++ b/ablog/post.py
@@ -216,11 +216,15 @@ def process_posts(app, doctree):
     if not post_nodes:
         return
     post_date_format = app.config['post_date_format']
+    should_auto_orphan = app.config['post_auto_orphan']
     docname = env.docname
 
-    # mark the post as 'orphan' so that
-    #   "document isn't included in any toctree" warning is not issued
-    app.env.metadata[docname]['orphan'] = True
+    if should_auto_orphan:
+        # mark the post as 'orphan' so that
+        #   "document isn't included in any toctree" warning is not issued
+        # We do not simply assign to should_auto_orphan because if auto-orphan
+        # is false, we still want to respect the per-post :rst:dir`orphan` setting
+        app.env.metadata[docname]['orphan'] = True
 
     blog = Blog(app)
     auto_excerpt = blog.post_auto_excerpt

--- a/ablog/start.py
+++ b/ablog/start.py
@@ -124,6 +124,12 @@ blog_authors = {
 # is ``False``.
 #post_always_section = False
 
+# When ``False``, the :rst:dir:`orphan` directive is not automatically set
+# for each post. Without this directive, Sphinx will warn about posts that
+# are not explicitly referenced via another document. :rst:dir:`orphan` can
+# be set on a per-post basis as well if this is false. Default is ``True``.
+#post_auto_orphan = True
+
 # -- ABlog Sidebars -------------------------------------------------------
 
 # There are seven sidebars you can include in your HTML output.


### PR DESCRIPTION
Allows use of ablog in more complex documentation where posts should be
linked. Default behavior is unchanged.

Should adequately fix #21. (Long-term, it may be worth thinking about how ablog documents the config options, but we're not less documented than some of our other options.)