### PR TITLE
Deploy improve

### DIFF
--- a/ablog/commands.py
+++ b/ablog/commands.py
@@ -511,7 +511,13 @@ def ablog_deploy(
             open(".nojekyll", "w")
             run("git add -f .nojekyll")
 
-        commit = 'git commit -m "{}"'.format(message or "Updates.")
+        # Check to see if anything has actually been committed
+        result = run('git diff --cached --name-status HEAD')
+        if (not result.stdout):
+            print('Nothing changed from last deployment')
+            return
+
+        commit = 'git commit -m "{}"'.format(message or 'Updates.')
         if push_force:
             commit += " --amend"
         run(commit, echo=True)

--- a/ablog/commands.py
+++ b/ablog/commands.py
@@ -404,6 +404,12 @@ def ablog_post(filename, title=None, **kwargs):
     help="environment variable name storing GitHub access token",
 )
 @arg(
+    "--github-ssh",
+    dest="github_is_http",
+    action="store_true",
+    help="use ssh when cloning website",
+)
+@arg(
     "--push-quietly",
     dest="push_quietly",
     action="store_true",
@@ -440,10 +446,10 @@ def ablog_deploy(
     push_quietly=False,
     push_force=False,
     github_token=None,
+    github_is_http=True,
     repodir=None,
     **kwargs,
 ):
-
     confdir = find_confdir()
     conf = read_conf(confdir)
 
@@ -470,7 +476,8 @@ def ablog_deploy(
             run("git pull", echo=True)
         else:
             run(
-                "git clone https://github.com/{0}/{0}.github.io.git {1}".format(
+                "git clone " + ("https://github.com/" if github_is_http else "git@github.com:") +
+                "{0}/{0}.github.io.git {1}".format(
                     github_pages, repodir
                 ),
                 echo=True,


### PR DESCRIPTION
Found a couple issues with deployment. First is that git clone always was trying http, so this will use ssh. Secondly was that deployment would cryptically fail if no changes had occurred, so now it checks for that returns a nice error message.