### PR TITLE
Change StopIteration to return

### DIFF
--- a/ablog/post.py
+++ b/ablog/post.py
@@ -588,7 +588,7 @@ def generate_atom_feeds(app):
 
     url = blog.blog_baseurl
     if not url:
-        raise StopIteration
+        return
 
     feed_path = os.path.join(app.builder.outdir, blog.blog_path, "atom.xml")
 


### PR DESCRIPTION
Fixes #47

Per [the docs](https://www.python.org/dev/peps/pep-0479/#examples-of-breakage)
changing it to `return` should be sufficient.