### PR TITLE
Pin werkzeug to < 1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
   sphinx-automodapi
   sphinx>=2.0
   watchdog
-  werkzeug
+  werkzeug<1
 
 [options.extras_require]
 notebook =


### PR DESCRIPTION
Might fix
```python
  File "/home/circleci/project/venv/lib/python3.6/site-packages/ablog/__init__.py", line 8, in <module>
    from .post import (
  File "/home/circleci/project/venv/lib/python3.6/site-packages/ablog/post.py", line 16, in <module>
    from werkzeug.contrib.atom import AtomFeed
ModuleNotFoundError: No module named 'werkzeug.contrib'
```