### PR TITLE
Use "dirhtml" builder on Read The Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,6 +7,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
+  builder: dirhtml
   configuration: docs/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub


### PR DESCRIPTION
There are many 404 errors ("not found") with links to
https://ablog.readthedocs.org/, e.g. https://ablog.readthedocs.org/blog/
(found under https://ablog.readthedocs.org/blog.html).

This changes the builder on Read The Docs from "html" to "dirhtml" to
generate the expected URLs.