### PR TITLE
Add intersphinx to the extension list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,10 +65,11 @@ If you already have a project, enable blogging by making following changes in ``
 
 .. code-block:: python
 
-  # 1. Add 'ablog' to list of extensions
+  # 1. Add 'ablog' and 'sphinx.ext.intersphinx' to the list of extensions
   extensions = [
       '...',
-      'ablog'
+      'ablog',
+      'sphinx.ext.intersphinx',
   ]
 
   # 2. Add ablog templates path

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,10 +47,11 @@ If you already have a project, enable blogging by making following changes in ``
 
 .. code-block:: python
 
-  # 1. Add 'ablog' to list of extensions
+  # 1. Add 'ablog' and 'sphinx.ext.intersphinx' to the list of extensions
   extensions = [
       '...',
-      'ablog'
+      'ablog',
+      'sphinx.ext.intersphinx',
   ]
 
   # 2. Add ablog templates path


### PR DESCRIPTION
As intersphinx is already added the list when a new ablog project is generated, I don't think we need to explain further.

Relevant to #59 and #18 