### PR TITLE
Add custom GitHub URL support

### DIFF
--- a/ablog/commands.py
+++ b/ablog/commands.py
@@ -360,6 +360,13 @@ def ablog_post(filename, title=None, **kwargs):
         print("Blog post created: %s" % filename)
 
 
+@arg("--github-url",
+     dest = "github_url",
+     type = str,
+     default = "git@github.com",
+     help = "Custom GitHub URL. Useful when multiple accounts are configured "
+     "on the same machine. Default is: git@github.com"
+)
 @arg(
     "--github-token",
     dest="github_token",
@@ -404,6 +411,7 @@ def ablog_deploy(
     push_force=False,
     github_token=None,
     github_is_http=True,
+    github_url=None,
     repodir=None,
     **kwargs,
 ):
@@ -412,6 +420,9 @@ def ablog_deploy(
     conf = read_conf(confdir)
 
     github_pages = github_pages or getattr(conf, "github_pages", None)
+
+    github_url = github_url or getattr(conf, "github_url", None)
+    github_url += ":"
 
     website = website or os.path.join(confdir, getattr(conf, "ablog_builddir", "_website"))
 
@@ -430,7 +441,7 @@ def ablog_deploy(
         else:
             run(
                 "git clone "
-                + ("https://github.com/" if github_is_http else "git@github.com:")
+                + ("https://github.com/" if github_is_http else github_url) # "git@github.com-mczakot:")
                 + "{0}/{0}.github.io.git {1}".format(github_pages, repodir),
                 echo=True,
             )

--- a/ablog/commands.py
+++ b/ablog/commands.py
@@ -441,7 +441,7 @@ def ablog_deploy(
         else:
             run(
                 "git clone "
-                + ("https://github.com/" if github_is_http else github_url) # "git@github.com-mczakot:")
+                + ("https://github.com/" if github_is_http else github_url)
                 + "{0}/{0}.github.io.git {1}".format(github_pages, repodir),
                 echo=True,
             )


### PR DESCRIPTION
Hi,

I've noticed that the GitHub URL is hard coded. It prevents pushing to repositories if there are multiple GitHub accounts configured on the same machine, e.g., if `~/.ssh/config` look like this:

```
Host github.com
    Hostname github.com
    User git
    IdentityFile ~/.ssh/main-user/github/id_rsa
    IdentitiesOnly yes

Host github.com-other-user-url
    Hostname github.com
    User git
    IdentityFile ~/.ssh/other-user/github/id_rsa
    IdentitiesOnly yes
```

The commit/push with custom URL can be invoked as:
```
ablog deploy -g other-user --github-url="git@github.com-other-user-url" -m "..."
```