### PR TITLE
Automatically add templates path to documentation

### DIFF
--- a/ablog/__init__.py
+++ b/ablog/__init__.py
@@ -71,6 +71,7 @@ def setup(app):
     app.add_directive("post", PostDirective)
     app.add_directive("postlist", PostListDirective)
 
+    app.connect("config-inited", config_inited)
     app.connect("doctree-read", process_posts)
 
     app.connect("env-purge-doc", purge_posts)
@@ -92,6 +93,10 @@ def setup(app):
     app.config.locale_dirs.append(locale_dir)
 
     return {"version": __version__}  # identifies the version of our extension
+
+
+def config_inited(app, config):
+    app.config.templates_path.append(get_html_templates_path())
 
 
 def get_html_templates_path():

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,8 +56,6 @@ html_favicon = "_static/ablog.ico"
 
 # ABLOG
 
-templates_path = [ablog.get_html_templates_path()]
-
 blog_title = "ABlog"
 blog_baseurl = "https://ablog.readthedocs.org"
 blog_locations = {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,14 +54,6 @@ If you already have a project, enable blogging by making following changes in ``
       'sphinx.ext.intersphinx',
   ]
 
-  # 2. Add ablog templates path
-  import ablog
-
-  # 2a. if `templates_path` is not defined
-  templates_path = [ablog.get_html_templates_path()]
-
-  # 2b. if `templates_path` is defined
-  templates_path.append(ablog.get_html_templates_path())
 
 .. _ABlog Quick Start: https://ablog.readthedocs.io/manual/ablog-quick-start.html
 


### PR DESCRIPTION
I noticed in the docs that it recommends manually adding the templates for this theme to the Sphinx templates path. I believe that this is something that could be automated which would simplify the install process for some folks.

With the changes in this PR I was able to remove the manual modification of the templates path from my build. What do you think?