### PR TITLE
frontmatter and blog post matching

### DIFF
--- a/ablog/__init__.py
+++ b/ablog/__init__.py
@@ -3,6 +3,7 @@ ABlog for Sphinx.
 """
 
 import os
+from glob import glob
 
 from .blog import CONFIG, Blog
 from .post import (
@@ -16,6 +17,7 @@ from .post import (
     process_postlist,
     process_posts,
     purge_posts,
+    CheckFrontMatter,
 )
 from .version import version as __version__
 
@@ -81,6 +83,7 @@ def setup(app):
     app.connect("html-collect-pages", generate_atom_feeds)
     app.connect("html-page-context", html_page_context)
 
+    app.add_transform(CheckFrontMatter)
     app.add_directive("update", UpdateDirective)
     app.add_node(
         UpdateNode,
@@ -97,6 +100,8 @@ def setup(app):
 
 def config_inited(app, config):
     app.config.templates_path.append(get_html_templates_path())
+    app.config.matched_blog_posts = [os.path.splitext(ii)[0]
+                                     for ii in glob(config.blog_post_pattern)]
 
 
 def get_html_templates_path():

--- a/ablog/blog.py
+++ b/ablog/blog.py
@@ -121,6 +121,7 @@ CONFIG = [
     ("disqus_shortname", None, True),
     ("disqus_drafts", False, True),
     ("disqus_pages", False, True),
+    ("blog_post_pattern", "", True, require_config_type(str)),
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,7 @@ blog_feed_length = None
 disqus_shortname = "ablogforsphinx"
 disqus_pages = True
 fontawesome_css_file = "css/font-awesome.css"
+blog_post_pattern = "release/ablog-v0.1-released*"
 
 # blog_feed_titles = False
 # blog_archive_titles = False

--- a/docs/release/ablog-v0.1-released.rst
+++ b/docs/release/ablog-v0.1-released.rst
@@ -1,11 +1,11 @@
+:tags: tips
+:author: Ahmet
+:category: Release
+:location: SF
+:date: May 14, 2014
+
 ABlog v0.1 released
 ===================
-
-.. post:: May 14, 2014
-   :tags: tips
-   :author: Ahmet
-   :category: Release
-   :location: SF
 
 
 ABlog v0.1 is released.


### PR DESCRIPTION
This PR adds two features:

- Front-matter can now be used to designate blog post metadata. We use a `blogpost: true` flag to designate a page as a "blog post"
- A configuration option to pattern-match filenames that will be treated as blog posts and have their front-matter used as blog post metadata (AKA, so you don't have to put `blogpost: true` for these files

The implementation may still need a bit of work but does this look good to folks in general? If folks are +1 I can add some docs for this

Also, I looked but I couldn't find any tests to add to. Am I missing something?

As one example, I converted one blog post to use front matter instead of the `post` directive:

- [demo page](https://ablog--69.org.readthedocs.build/release/ablog-v0.1-released/)
- [diff in rst file](https://github.com/sunpy/ablog/pull/69/files#diff-f53a5f444e5b3e175a0d082c993040bb)

closes #68 