### PR TITLE
Fix missing reference caused by ref with title

### DIFF
--- a/ablog/post.py
+++ b/ablog/post.py
@@ -213,6 +213,7 @@ def purge_posts(app, env, docname):
 
     filename = os.path.split(docname)[1]
     env.domains["std"].data["labels"].pop(filename, None)
+    env.domains["std"].data["anonlabels"].pop(filename, None)
 
 
 def _update_post_node(node, options, arguments):
@@ -391,6 +392,7 @@ def process_posts(app, doctree):
             # if it is posting the document
             # ! this does not work for sections
             app.env.domains["std"].data["labels"][label] = (docname, label, title)
+            app.env.domains["std"].data["anonlabels"][label] = (docname, label)
 
         if section.parent is doctree:
             section_copy = section[0].deepcopy()


### PR DESCRIPTION
# Probem

Currently, `:ref:` with title is not working.

## Example

index.rst

```rst
=========
example
=========

.. postlist::
   :list-style: disk

Cross-referencing
---------------------

.. This works well
* :ref:`post1` 

.. This does not work
* :ref:`My first post! <post1>`
```

post1.rst

```rst
.. post:: Oct 5, 2020
   :author: me

=======
post1
=======

welcome to my blog!
```

## Build result 

generated index.html (excerpted)

```html
<ul class="simple">
<li><p><a class="reference internal" href="post1/#post1"><span class="std std-ref">post1</span></a></p></li>
<li><p><span class="xref std std-ref">My first post!</span></p></li>
</ul>
```
log

```
Running Sphinx v3.2.1
loading translations [en]... done
making output directory... done
building [mo]: targets for 0 po files that are out of date
building [dirhtml]: targets for 2 source files that are out of date
updating environment: [new config] 2 added, 0 changed, 0 removed
reading sources... [100%] post1
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done

WARNING:root:error, missing reference: post1, <inline classes="xref std std-ref">My first post!</inline>

writing output... [100%] post1
/project/example/index.rst:12: WARNING: undefined label: post1 (if the link has no caption the label must precede a section header)
generating indices...  genindexdone
writing additional pages...  searchdone
copying static files... ... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 1 warning.
```
## version

* ablog==0.10.10 
* sphinx==3.2.1

# Solution

After several hours of research (the internals of the sphinx are difficult!) I understand that in [sphinx.domains.std.StandardDomain._resolve_ref_xref](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/domains/std.py#L796), if refexplicit is true, it refers to the value of *domain.anonlabels* . 

So i modified ablog to add anonlabels where labels added. and it works well against above example.

Thanks for all contributers time and effort. 