### PR TITLE
improving glob matching and documenting it

### DIFF
--- a/ablog/__init__.py
+++ b/ablog/__init__.py
@@ -100,7 +100,14 @@ def setup(app):
 
 def config_inited(app, config):
     app.config.templates_path.append(get_html_templates_path())
-    app.config.matched_blog_posts = [os.path.splitext(ii)[0] for ii in glob(config.blog_post_pattern)]
+
+    # Automatically identify any blog posts if a pattern is specified in the config
+    if isinstance(config.blog_post_pattern, str):
+        config.blog_post_pattern = [config.blog_post_pattern]
+    matched_patterns = []
+    for pattern in config.blog_post_pattern:
+        matched_patterns.extend(os.path.splitext(ii)[0] for ii in glob(pattern, recursive=True))
+    app.config.matched_blog_posts = matched_patterns
 
 
 def get_html_templates_path():

--- a/ablog/blog.py
+++ b/ablog/blog.py
@@ -121,7 +121,7 @@ CONFIG = [
     ("disqus_shortname", None, True),
     ("disqus_drafts", False, True),
     ("disqus_pages", False, True),
-    ("blog_post_pattern", "", True, require_config_type(str)),
+    ("blog_post_pattern", [], True, require_config_type((str, list))),
 ]
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,7 +39,7 @@ This will also install `Sphinx <http://sphinx-doc.org/>`__, `feedgen <https://gi
 Getting Started
 ---------------
 
-If you are starting a new project, see `ABlog Quick Start`_ guide.
+If you are starting a new project, see the :ref:`quick-start` guide.
 If you already have a project, enable blogging by making following changes in ``conf.py``:
 
 .. code-block:: python
@@ -50,8 +50,6 @@ If you already have a project, enable blogging by making following changes in ``
       'ablog',
       'sphinx.ext.intersphinx',
   ]
-
-.. _ABlog Quick Start: https://ablog.readthedocs.io/manual/ablog-quick-start.html
 
 How it works
 ------------

--- a/docs/manual/ablog-quick-start.rst
+++ b/docs/manual/ablog-quick-start.rst
@@ -84,6 +84,8 @@ Simply use something based on the following template as the directive for ABlog:
   :language: English
   :tags: blog
 
+For more information, see :ref:`posting-directive` and :ref:`posting-front-matter`.
+
 Comments
 --------
 

--- a/docs/manual/posting-and-listing.rst
+++ b/docs/manual/posting-and-listing.rst
@@ -86,26 +86,21 @@ Any page in a Sphinx_ project can be converted to a post using the following dir
 Posting with page front-matter
 ------------------------------
 
-If you'd prefer to use `page front matter <https://www.sphinx-doc.org/en/1.7/markup/misc.html>`__
-instead of using a directive, you may mark a page as a "blog post" by adding
-the following front-matter at the top:
+If you'd prefer to use `page front matter <https://www.sphinx-doc.org/en/1.7/markup/misc.html>`__ instead of using a directive, you may mark a page as a "blog post" by adding the following front-matter at the top:
 
 .. code-block:: rst
 
    :blogpost: true
 
-``ABlog`` will treat any pages with this front-matter as a blog post. All fields that are
-available to the :ref:`posting directive <posting-directive>` can be given as page-level
-front-matter as well.
+``ABlog`` will treat any pages with this front-matter as a blog post.
+All fields that are available to the :ref:`posting directive <posting-directive>` can be given as page-level front-matter as well.
 
 .. admonition:: Automatically detect blog posts with a ``glob`` pattern
    :class: tip
 
-   Instead of adding ``blogpost: true`` to each page, you may also provide
-   a pattern (or list of patterns) in your ``conf.py`` file using the ``blog_post_pattern``
-   option. Any filenames that match this pattern will be treated as blog posts (and page
-   front-matter will be used to classify the blog post). For example, the following configuration
-   would match all rst files in the ``posts/`` folder:
+   Instead of adding ``blogpost: true`` to each page, you may also provide a pattern (or list of patterns) in your ``conf.py`` file using the ``blog_post_pattern`` option.
+   Any filenames that match this pattern will be treated as blog posts (and page front-matter will be used to classify the blog post).
+   For example, the following configuration would match all ``rst`` files in the ``posts/`` folder:
 
    .. code-block:: python
 

--- a/docs/manual/posting-and-listing.rst
+++ b/docs/manual/posting-and-listing.rst
@@ -9,8 +9,10 @@ Posting and Listing
 
 This post describes :rst:dir:`post`, :rst:dir:`update`, and :rst:dir:`postlist` directives.
 
-Posting
--------
+.. _posting-directive:
+
+Posting with a Directive
+------------------------
 
 Any page in a Sphinx_ project can be converted to a post using the following directive:
 
@@ -78,6 +80,43 @@ Any page in a Sphinx_ project can be converted to a post using the following dir
       Update date format must follow the format specified with :confval:`post_date_format` configuration option.
 
       Update directive renders like the updates that are at the end of this post.
+
+.. _posting-front-matter:
+
+Posting with page front-matter
+------------------------------
+
+If you'd prefer to use `page front matter <https://www.sphinx-doc.org/en/1.7/markup/misc.html>`_
+instead of using a directive, you may mark a page as a "blog post" by adding
+the following front-matter at the top:
+
+.. code-block:: rst
+
+   :blogpost: true
+
+``ABlog`` will treat any pages with this front-matter as a blog post. All fields that are
+available to the :ref:`posting directive <posting-directive>` can be given as page-level
+front-matter as well.
+
+.. admonition:: Automatically detect blog posts with a ``glob`` pattern 
+   :class: tip
+
+   Instead of adding ``blogpost: true`` to each page, you may also provide
+   a pattern (or list of patterns) in your ``conf.py`` file using the ``blog_post_pattern``
+   option. Any filenames that match this pattern will be treated as blog posts (and page
+   front-matter will be used to classify the blog post). For example, the following configuration
+   would match all rst files in the ``posts/`` folder:
+
+   .. code-block:: python
+
+      blog_post_pattern = "posts/*.rst"
+
+   and this configuration will match all blog posts that match either ``rst`` or ``md``:
+
+   .. code-block:: python
+
+      blog_post_pattern = ["posts/*.rst", "posts/*.md"]
+
 
 .. _posting-sections:
 

--- a/docs/manual/posting-and-listing.rst
+++ b/docs/manual/posting-and-listing.rst
@@ -86,7 +86,7 @@ Any page in a Sphinx_ project can be converted to a post using the following dir
 Posting with page front-matter
 ------------------------------
 
-If you'd prefer to use `page front matter <https://www.sphinx-doc.org/en/1.7/markup/misc.html>`_
+If you'd prefer to use `page front matter <https://www.sphinx-doc.org/en/1.7/markup/misc.html>`__
 instead of using a directive, you may mark a page as a "blog post" by adding
 the following front-matter at the top:
 

--- a/docs/manual/posting-and-listing.rst
+++ b/docs/manual/posting-and-listing.rst
@@ -98,7 +98,7 @@ the following front-matter at the top:
 available to the :ref:`posting directive <posting-directive>` can be given as page-level
 front-matter as well.
 
-.. admonition:: Automatically detect blog posts with a ``glob`` pattern 
+.. admonition:: Automatically detect blog posts with a ``glob`` pattern
    :class: tip
 
    Instead of adding ``blogpost: true`` to each page, you may also provide

--- a/docs/manual/posting-and-listing.rst
+++ b/docs/manual/posting-and-listing.rst
@@ -117,7 +117,6 @@ front-matter as well.
 
       blog_post_pattern = ["posts/*.rst", "posts/*.md"]
 
-
 .. _posting-sections:
 
 Posting Sections


### PR DESCRIPTION
This is a follow-up to #71 and #69 . It does the following:

- Improves the `glob` matching so that you can search recursively, and so that you can provide a list of multiple glob patterns (e.g. if you want to search for two file types)
- Documents the `glob` matching functionality (so folks know that they have another option to putting `blogpost: true` in the front-matter)
- Adds some more documentation around front-matter behavior etc
- Adds some labels and updates some `ref`s
