### PR TITLE
Ensure `blog_post_pattern` are relative to srcdir

### DIFF
--- a/ablog/__init__.py
+++ b/ablog/__init__.py
@@ -108,8 +108,7 @@ def config_inited(app, config):
     for pattern in config.blog_post_pattern:
         pattern = os.path.join(app.srcdir, pattern)
         matched_patterns.extend(
-            os.path.relpath(os.path.splitext(ii)[0], app.srcdir)
-            for ii in glob(pattern, recursive=True)
+            os.path.relpath(os.path.splitext(ii)[0], app.srcdir) for ii in glob(pattern, recursive=True)
         )
     app.config.matched_blog_posts = matched_patterns
 

--- a/ablog/__init__.py
+++ b/ablog/__init__.py
@@ -106,7 +106,11 @@ def config_inited(app, config):
         config.blog_post_pattern = [config.blog_post_pattern]
     matched_patterns = []
     for pattern in config.blog_post_pattern:
-        matched_patterns.extend(os.path.splitext(ii)[0] for ii in glob(pattern, recursive=True))
+        pattern = os.path.join(app.srcdir, pattern)
+        matched_patterns.extend(
+            os.path.relpath(os.path.splitext(ii)[0], app.srcdir)
+            for ii in glob(pattern, recursive=True)
+        )
     app.config.matched_blog_posts = matched_patterns
 
 


### PR DESCRIPTION
Currently, the `glob` assumes the current working directory is the documents source directory.
This is most certainly not always the case, for example when running sphinx build via tox: https://github.com/executablebooks/sphinx-book-theme/blob/9bc35d25e361a9dace07a470c59003d056dc0671/tox.ini#L38

This PR ensures that `blog_post_pattern` is taken relative to the `app.srcdir`.