### PR TITLE
feat(feeds): Add missing Atom entry metadata

### DIFF
--- a/ablog/post.py
+++ b/ablog/post.py
@@ -726,10 +726,13 @@ def generate_atom_feeds(app):
             feed_entry = feed.add_entry()
             feed_entry.id(post_url)
             feed_entry.title(post.title)
+            feed_entry.summary(" ".join(paragraph.astext() for paragraph in post.excerpt[0]))
             feed_entry.link(href=post_url)
             feed_entry.author({"name": author.name for author in post.author})
             feed_entry.pubDate(post.date.astimezone())
             feed_entry.updated(post.update.astimezone())
+            for tag in post.tags:
+                feed_entry.category(dict(term=tag.name, label=tag.label))
             feed_entry.content(content=content, type="html")
 
         parent_dir = os.path.dirname(feed_path)

--- a/tests/roots/test-build/conf.py
+++ b/tests/roots/test-build/conf.py
@@ -1,1 +1,6 @@
 extensions = ["ablog"]
+
+# Enable Atom feed generation
+blog_baseurl = u"https://blog.example.com/"
+# Include full post in feeds
+blog_feed_fulltext = True

--- a/tests/roots/test-build/post.rst
+++ b/tests/roots/test-build/post.rst
@@ -1,4 +1,6 @@
 .. post:: 2020-12-01
 
-post
-=======
+Foo Post Title
+==============
+
+Foo post content.

--- a/tests/roots/test-build/post.rst
+++ b/tests/roots/test-build/post.rst
@@ -1,6 +1,9 @@
 .. post:: 2020-12-01
+   :tags: Foo Tag, BarTag
 
 Foo Post Title
 ==============
+
+    Foo post description.
 
 Foo post content.

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -31,5 +31,11 @@ def test_feed(app, status, warning):
     entry = entries[0]
     title = entry.find("{http://www.w3.org/2005/Atom}title")
     assert title.text == "Foo Post Title", "Wrong Atom feed entry title"
+    summary = entry.find("{http://www.w3.org/2005/Atom}summary")
+    assert summary.text == "Foo post description.", "Wrong Atom feed entry summary"
+    categories = entry.findall("{http://www.w3.org/2005/Atom}category")
+    assert len(categories) == 2, "Wrong number of Atom feed categories"
+    assert categories[0].attrib["label"] == "Foo Tag", "Wrong Atom feed first category"
+    assert categories[1].attrib["label"] == "BarTag", "Wrong Atom feed second category"
     content = entry.find("{http://www.w3.org/2005/Atom}content")
     assert "Foo post content." in content.text, "Wrong Atom feed entry content"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,3 +1,4 @@
+import lxml
 import pytest
 
 
@@ -9,3 +10,26 @@ def test_build(app, status, warning):
     assert (app.outdir / "index.html").exists()
     assert (app.outdir / "blog/archive.html").exists()
     assert (app.outdir / "post.html").exists()
+
+
+@pytest.mark.sphinx("html", testroot="build")  # using roots/test-build
+def test_feed(app, status, warning):
+    """
+    Atom syndication feeds are built correctly.
+    """
+    app.build()
+    assert app.statuscode == 0, "Test ABlog project did not build successfully"
+
+    feed_path = app.outdir / "blog/atom.xml"
+    assert (feed_path).exists(), "Atom feed was not built"
+
+    with feed_path.open() as feed_opened:
+        feed_tree = lxml.etree.parse(feed_opened)
+    entries = feed_tree.findall("{http://www.w3.org/2005/Atom}entry")
+    assert len(entries) == 1, "Wrong number of Atom feed entries"
+
+    entry = entries[0]
+    title = entry.find("{http://www.w3.org/2005/Atom}title")
+    assert title.text == "Foo Post Title", "Wrong Atom feed entry title"
+    content = entry.find("{http://www.w3.org/2005/Atom}content")
+    assert "Foo post content." in content.text, "Wrong Atom feed entry content"


### PR DESCRIPTION
Adds test coverage for existing Atom feed generation and then adds some missing feed
metadata to generated feeds: summary and categories.

----

I checked locally, `$ tox -p all` passes successfully.

Fixes #91