### PR TITLE
feat(feeds): Add entry element template support

### DIFF
--- a/ablog/blog.py
+++ b/ablog/blog.py
@@ -101,6 +101,7 @@ CONFIG = [
     ("blog_feed_fulltext", False, True),
     ("blog_feed_subtitle", None, True),
     ("blog_feed_titles", None, False),
+    ("blog_feed_templates", {"atom": {}}, True),
     ("blog_feed_length", None, None),
     ("blog_authors", {}, True, require_config_full_name_link_dict()),
     ("blog_default_author", None, True, require_config_str_or_list_lookup("blog_authors")),

--- a/ablog/post.py
+++ b/ablog/post.py
@@ -726,10 +726,13 @@ def generate_atom_feeds(app):
             feed_entry = feed.add_entry()
             feed_entry.id(post_url)
             feed_entry.title(post.title)
+            feed_entry.summary(" ".join(paragraph.astext() for paragraph in post.excerpt[0]))
             feed_entry.link(href=post_url)
             feed_entry.author({"name": author.name for author in post.author})
             feed_entry.pubDate(post.date.astimezone())
             feed_entry.updated(post.update.astimezone())
+            for tag in post.tags:
+                feed_entry.category(dict(term=tag.name, label=tag.label))
             feed_entry.content(content=content, type="html")
 
         parent_dir = os.path.dirname(feed_path)

--- a/ablog/post.py
+++ b/ablog/post.py
@@ -732,7 +732,10 @@ def generate_atom_feeds(app):
             feed_entry.pubDate(post.date.astimezone())
             feed_entry.updated(post.update.astimezone())
             for tag in post.tags:
-                feed_entry.category(dict(term=tag.name, label=tag.label))
+                feed_entry.category(dict(
+                    term=tag.name.strip().replace(" ", ""),
+                    label=tag.label,
+                ))
             feed_entry.content(content=content, type="html")
 
         parent_dir = os.path.dirname(feed_path)

--- a/ablog/post.py
+++ b/ablog/post.py
@@ -6,6 +6,7 @@ import logging
 from string import Formatter
 from datetime import datetime
 
+import jinja2
 from dateutil.parser import parse as date_parser
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -656,16 +657,16 @@ def generate_atom_feeds(app):
     if not url:
         return
 
-    feed_path = os.path.join(app.builder.outdir, blog.blog_path, "atom.xml")
-
     feeds = [
         (
             blog.posts,
             blog.blog_path,
-            feed_path,
+            os.path.join(app.builder.outdir, blog.blog_path, feed_root + ".xml"),
             blog.blog_title,
-            os_path_join(url, blog.blog_path, "atom.xml"),
+            os_path_join(url, blog.blog_path, feed_root + ".xml"),
+            feed_templates,
         )
+        for feed_root, feed_templates in blog.blog_feed_templates.items()
     ]
 
     if blog.blog_feed_archives:
@@ -686,21 +687,23 @@ def generate_atom_feeds(app):
                 if not os.path.isdir(folder):
                     os.makedirs(folder)
 
-                feeds.append(
-                    (
-                        coll,
-                        coll.path,
-                        os.path.join(folder, "atom.xml"),
-                        blog.blog_title + " - " + header + " " + text_type(coll),
-                        os_path_join(url, coll.path, "atom.xml"),
+                for feed_root, feed_templates in blog.blog_feed_templates.items():
+                    feeds.append(
+                        (
+                            coll,
+                            coll.path,
+                            os.path.join(folder, feed_root + ".xml"),
+                            blog.blog_title + " - " + header + " " + text_type(coll),
+                            os_path_join(url, coll.path, feed_root + ".xml"),
+                            feed_templates,
+                        )
                     )
-                )
 
     # Config options
     feed_length = blog.blog_feed_length
     feed_fulltext = blog.blog_feed_fulltext
 
-    for feed_posts, pagename, feed_path, feed_title, feed_url in feeds:
+    for feed_posts, pagename, feed_path, feed_title, feed_url, feed_templates in feeds:
 
         feed = FeedGenerator()
         feed.id(blog.blog_baseurl)
@@ -725,18 +728,28 @@ def generate_atom_feeds(app):
 
             feed_entry = feed.add_entry()
             feed_entry.id(post_url)
-            feed_entry.title(post.title)
-            feed_entry.summary(" ".join(paragraph.astext() for paragraph in post.excerpt[0]))
             feed_entry.link(href=post_url)
             feed_entry.author({"name": author.name for author in post.author})
             feed_entry.pubDate(post.date.astimezone())
             feed_entry.updated(post.update.astimezone())
             for tag in post.tags:
-                feed_entry.category(dict(
-                    term=tag.name.strip().replace(" ", ""),
-                    label=tag.label,
-                ))
-            feed_entry.content(content=content, type="html")
+                feed_entry.category(
+                    dict(
+                        term=tag.name.strip().replace(" ", ""),
+                        label=tag.label,
+                    )
+                )
+
+            # Entry values that support templates
+            title = post.title
+            summary = " ".join(paragraph.astext() for paragraph in post.excerpt[0])
+            template_values = {}
+            for element in ("title", "summary", "content"):
+                if element in feed_templates:
+                    template_values[element] = jinja2.Template(feed_templates[element]).render(**locals())
+            feed_entry.title(template_values.get("title", title))
+            feed_entry.summary(template_values.get("summary", summary))
+            feed_entry.content(content=template_values.get("content", content), type="html")
 
         parent_dir = os.path.dirname(feed_path)
         if not os.path.isdir(parent_dir):

--- a/ablog/start.py
+++ b/ablog/start.py
@@ -142,6 +142,23 @@ html_sidebars = {
 # Choose to feed only post titles, default is ``False``.
 # blog_feed_titles = False
 
+# Specify custom Jinja2 templates for feed entry elements:
+#     `title`, `summary`, or `content`
+# For example, to add an additional feed for posting to social media:
+# blog_feed_templates = {
+#     # Use defaults, no templates
+#     "atom": {},
+#     # Create content text suitable posting to social media
+#     "social": {
+#         # Format tags as hashtags and append to the content
+#         "content": "{{ title }}{% for tag in post.tags %}"
+#         " #{{ tag.name|trim()|replace(' ', '') }}"
+#         "{% endfor %}",
+#     },
+# }
+# Default: Create one `atom.xml` feed without any templates
+# blog_feed_templates = {"atom": {}}
+
 # Specify number of recent posts to include in feeds, default is ``None``
 # for all posts.
 # blog_feed_length = None

--- a/docs/manual/ablog-configuration-options.rst
+++ b/docs/manual/ablog-configuration-options.rst
@@ -137,6 +137,42 @@ Turn feeds on by setting :confval:`blog_baseurl` configuration variable.
 
    Choose to feed only post titles, default is ``False``.
 
+.. confval:: blog_feed_templates
+
+   A dictionary of feed filename roots mapping to nested dictionaries of feed entry
+   elements, ``title``, ``summary``, and/or ``content``, and a `Jink2`_ template which will be
+   used to render the value used for that element in that feed.  Templates are rendered
+   with the the following context:
+   - ``feed_length``
+   - ``feed_fulltext``
+   - ``feed_posts``
+   - ``pagename``
+   - ``feed_title``
+   - ``feed_url``
+   - ``feed``
+   - ``post``
+   - ``post_url``
+   - ``content``
+   - ``feed_entry``
+   - ``title``
+   - ``summary``
+   - ``blog``
+   - ``url``
+   - ``app``
+   Default is: ``{"atom": {}}``
+   Example to add an additional feed for posting to social media::
+     blog_feed_templates = {
+         # Use defaults, no templates
+         "atom": {},
+         # Create content text suitable posting to social media
+         "social": {
+             # Format tags as hashtags and append to the content
+             "content": "{{ title }}{% for tag in post.tags %}"
+             " #{{ tag.name|trim()|replace(' ', '') }}"
+             "{% endfor %}",
+         },
+     }
+
 .. confval:: blog_feed_length
 
    Specify number of recent posts to include in feeds, default is ``None`` for all posts.
@@ -149,7 +185,12 @@ Turn feeds on by setting :confval:`blog_baseurl` configuration variable.
 
    Added :confval:`blog_feed_titles`, :confval:`blog_feed_length`, and :confval:`blog_archive_titles` options.
 
+.. update:: Mar 20, 2021
+
+   Added :confval:`blog_feed_templates` option.
+
 .. _fa:
+.. _Jinja2: https://jinja.palletsprojects.com/
 
 Font awesome
 ------------

--- a/docs/manual/ablog-configuration-options.rst
+++ b/docs/manual/ablog-configuration-options.rst
@@ -140,7 +140,7 @@ Turn feeds on by setting :confval:`blog_baseurl` configuration variable.
 .. confval:: blog_feed_templates
 
    A dictionary of feed filename roots mapping to nested dictionaries of feed entry
-   elements, ``title``, ``summary``, and/or ``content``, and a `Jink2`_ template which will be
+   elements, ``title``, ``summary``, and/or ``content``, and a `Jinja2`_ template which will be
    used to render the value used for that element in that feed.  Templates are rendered
    with the the following context:
    - ``feed_length``

--- a/tests/roots/test-build/conf.py
+++ b/tests/roots/test-build/conf.py
@@ -1,1 +1,6 @@
 extensions = ["ablog"]
+
+# Enable Atom feed generation
+blog_baseurl = u"https://blog.example.com/"
+# Include full post in feeds
+blog_feed_fulltext = True

--- a/tests/roots/test-build/conf.py
+++ b/tests/roots/test-build/conf.py
@@ -4,3 +4,15 @@ extensions = ["ablog"]
 blog_baseurl = u"https://blog.example.com/"
 # Include full post in feeds
 blog_feed_fulltext = True
+# Add a social media Atom feed
+blog_feed_templates = {
+    # Use defaults, no templates
+    "atom": {},
+    # Create content text suitable posting to micro-bogging
+    "social": {
+        # Format tags as hashtags and append to the content
+        "content": "{{ title }}{% for tag in post.tags %}"
+        " #{{ tag.name|trim()|replace(' ', '') }}"
+        "{% endfor %}",
+    },
+}

--- a/tests/roots/test-build/post.rst
+++ b/tests/roots/test-build/post.rst
@@ -1,4 +1,6 @@
 .. post:: 2020-12-01
 
-post
-=======
+Foo Post Title
+==============
+
+Foo post content.

--- a/tests/roots/test-build/post.rst
+++ b/tests/roots/test-build/post.rst
@@ -1,6 +1,9 @@
 .. post:: 2020-12-01
+   :tags: Foo Tag, BarTag
 
 Foo Post Title
 ==============
+
+    Foo post description.
 
 Foo post content.

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -31,5 +31,11 @@ def test_feed(app, status, warning):
     entry = entries[0]
     title = entry.find("{http://www.w3.org/2005/Atom}title")
     assert title.text == "Foo Post Title", "Wrong Atom feed entry title"
+    summary = entry.find("{http://www.w3.org/2005/Atom}summary")
+    assert summary.text == "Foo post description.", "Wrong Atom feed entry summary"
+    categories = entry.findall("{http://www.w3.org/2005/Atom}category")
+    assert len(categories) == 2, "Wrong number of Atom feed categories"
+    assert categories[0].attrib["label"] == "Foo Tag", "Wrong Atom feed first category"
+    assert categories[1].attrib["label"] == "BarTag", "Wrong Atom feed second category"
     content = entry.find("{http://www.w3.org/2005/Atom}content")
     assert "Foo post content." in content.text, "Wrong Atom feed entry content"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -36,6 +36,8 @@ def test_feed(app, status, warning):
     categories = entry.findall("{http://www.w3.org/2005/Atom}category")
     assert len(categories) == 2, "Wrong number of Atom feed categories"
     assert categories[0].attrib["label"] == "Foo Tag", "Wrong Atom feed first category"
+    assert categories[0].attrib["term"] == "FooTag", "Wrong Atom feed first category"
     assert categories[1].attrib["label"] == "BarTag", "Wrong Atom feed second category"
+    assert categories[1].attrib["term"] == "BarTag", "Wrong Atom feed second category"
     content = entry.find("{http://www.w3.org/2005/Atom}content")
     assert "Foo post content." in content.text, "Wrong Atom feed entry content"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,3 +1,4 @@
+import lxml
 import pytest
 
 
@@ -9,3 +10,26 @@ def test_build(app, status, warning):
     assert (app.outdir / "index.html").exists()
     assert (app.outdir / "blog/archive.html").exists()
     assert (app.outdir / "post.html").exists()
+
+
+@pytest.mark.sphinx("html", testroot="build")  # using roots/test-build
+def test_feed(app, status, warning):
+    """
+    Atom syndication feeds are built correctly.
+    """
+    app.build()
+    assert app.statuscode == 0, "Test ABlog project did not build successfully"
+
+    feed_path = app.outdir / "blog/atom.xml"
+    assert (feed_path).exists(), "Atom feed was not built"
+
+    with feed_path.open() as feed_opened:
+        feed_tree = lxml.etree.parse(feed_opened)
+    entries = feed_tree.findall("{http://www.w3.org/2005/Atom}entry")
+    assert len(entries) == 1, "Wrong number of Atom feed entries"
+
+    entry = entries[0]
+    title = entry.find("{http://www.w3.org/2005/Atom}title")
+    assert title.text == "Foo Post Title", "Wrong Atom feed entry title"
+    content = entry.find("{http://www.w3.org/2005/Atom}content")
+    assert "Foo post content." in content.text, "Wrong Atom feed entry content"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -41,3 +41,23 @@ def test_feed(app, status, warning):
     assert categories[1].attrib["term"] == "BarTag", "Wrong Atom feed second category"
     content = entry.find("{http://www.w3.org/2005/Atom}content")
     assert "Foo post content." in content.text, "Wrong Atom feed entry content"
+
+    social_path = app.outdir / "blog/social.xml"
+    assert (social_path).exists(), "Social media feed was not built"
+
+    with social_path.open() as social_opened:
+        social_tree = lxml.etree.parse(social_opened)
+    social_entries = social_tree.findall("{http://www.w3.org/2005/Atom}entry")
+    assert len(social_entries) == len(entries), "Wrong number of Social media feed entries"
+
+    social_entry = social_entries[0]
+    title = social_entry.find("{http://www.w3.org/2005/Atom}title")
+    assert title.text == "Foo Post Title", "Wrong Social media feed entry title"
+    summary = social_entry.find("{http://www.w3.org/2005/Atom}summary")
+    assert summary.text == "Foo post description.", "Wrong Social media feed entry summary"
+    categories = social_entry.findall("{http://www.w3.org/2005/Atom}category")
+    assert len(categories) == 2, "Wrong number of Social media feed categories"
+    assert categories[0].attrib["label"] == "Foo Tag", "Wrong Social media feed first category"
+    assert categories[1].attrib["label"] == "BarTag", "Wrong Social media feed second category"
+    content = social_entry.find("{http://www.w3.org/2005/Atom}content")
+    assert "Foo Post Title #FooTag #BarTag" in content.text, "Wrong Social media feed entry content"


### PR DESCRIPTION
Syndication feeds are often used to interact with external services.  [Planet
Venus](http://intertwingly.net/code/venus/docs/index.html), for example, aggregates
multiple feeds into one topical 'Planet Foo' type site.  Various other services consume
syndication feeds to automatically make social media posts when new entries appear in
the feed.  Whether to comply with community standards on a `Planet Foo` type site or to
feed richer data to an external service whose support for Atom elements is limited, such
as [IFTTT's RSS Feed Service](https://ifttt.com/feed), having rich control over feed
entry element values supports many use cases.

This change adds support for such use cases using Jinja2, as it's already a dependency
of Sphinx, string templates in a new project configuration option.  I've added test
coverage, `$ tox -p all` succeeds locally, and I also tested locally in my own ABlog
project.  It seems to work well.


----

Note that this PR is based on top of #92.