### PR TITLE
Correct draft URL

### DIFF
--- a/ablog/blog.py
+++ b/ablog/blog.py
@@ -228,7 +228,7 @@ class Blog(Container):
         # add references to posts and drafts
         # e.g. :ref:`blog-posts`
         refs["blog-posts"] = (os_path_join(self.config["blog_path"], "index"), "Posts")
-        refs["blog-drafts"] = (os_path_join(self.config["blog_path"], "drafts", "index"), "Drafts")
+        refs["blog-drafts"] = (os_path_join(self.config["blog_path"], "drafts"), "Drafts")
         refs["blog-feed"] = (os_path_join(self.config["blog_path"], "atom.xml"), self.blog_title + " Feed")
 
         # set some internal configuration options


### PR DESCRIPTION
role ``:ref:`blog-drafts` `` produces a wrong URL.

The drafts URL should be `$BLOG_PATH/drafts.html`. but not `$BLOG_PATH/drafts/index.html`.

But I dont known why https://ablog.readthedocs.io/manual/cross-referencing-blog-pages/ works.