### PR TITLE
Correct posts URL

### DIFF
--- a/ablog/blog.py
+++ b/ablog/blog.py
@@ -227,7 +227,7 @@ class Blog(Container):
 
         # add references to posts and drafts
         # e.g. :ref:`blog-posts`
-        refs["blog-posts"] = (os_path_join(self.config["blog_path"], "index"), "Posts")
+        refs["blog-posts"] = (self.config["blog_path"], "Posts")
         refs["blog-drafts"] = (os_path_join(self.config["blog_path"], "drafts"), "Drafts")
         refs["blog-feed"] = (os_path_join(self.config["blog_path"], "atom.xml"), self.blog_title + " Feed")
 


### PR DESCRIPTION
ABlog create `<blog_path>.html` but not `<blog_path>/index.html`.

It is strange that all ```:ref:`blog-*` ``` references point to wrong URLs :'(