### PR TITLE
rename master to main

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,14 +3,14 @@ ABlog for Sphinx
 
 |Build Status|
 
-.. |Build Status| image:: https://dev.azure.com/sunpy/ablog/_apis/build/status/sunpy.ablog?repoName=sunpy%2Fablog&branchName=master
-   :target: https://dev.azure.com/sunpy/ablog/_build/latest?definitionId=17&repoName=sunpy%2Fablog&branchName=master
+.. |Build Status| image:: https://dev.azure.com/sunpy/ablog/_apis/build/status/sunpy.ablog?repoName=sunpy%2Fablog&branchName=main
+   :target: https://dev.azure.com/sunpy/ablog/_build/latest?definitionId=17&repoName=sunpy%2Fablog&branchName=main
 
 Note
 ----
 
 Please note that is an official new home of `Ahmet Bakan's Ablog Sphinx extension <https://github.com/abakan/ablog/>`__.
-This version is maintined with the aim to keep it working for SunPy's website and thus new features are **highly unlikely**.
+This version is maintained with the aim to keep it working for SunPy's website and thus new features are **highly unlikely**.
 
 ABlog
 -----

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ schedules:
     displayName: Daily midnight build
     branches:
       include:
-      - master
+      - main
     always: true
 
 resources:
@@ -68,7 +68,7 @@ stages:
         envs:
           - macos: py36
           - windows: py36-sphinx3
-          - linux: py37
+          - linux: py37-sphinx2
           - linux: py37-sphinx3
           - linux: py39-sphinx3
           - linux: py38-sphinxdev

--- a/docs/release/ablog-v0.9-released.rst
+++ b/docs/release/ablog-v0.9-released.rst
@@ -81,6 +81,6 @@ ABlog v0.9.5 released
    :location: World
 
 v0.9.5 is the that supports Python 2 and Sphinx <2.
-v0.10.0 on master now, will not.
+v0.10.0 on main now, will not.
 
 `Define an auto-orphan option <https://github.com/sunpy/ablog/pull/39>`__, `Repair update directive <https://github.com/sunpy/ablog/pull/37>`__ and `Fix sidebar and blog_baseurl misconfig during quick start <https://github.com/sunpy/ablog/pull/36>`__ from `rayalan <https://github.com/rayalan>`__.

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ markdown =
 docs =
   alabaster
   sphinx-automodapi
-test =
+tests =
   pytest
 
 [options.entry_points]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,11 @@
 [tox]
 envlist =
-    py{36,37,38,39}{,-sphinx2,-sphinx3,-sphinxdev,-docs}
+    py{36,37,38,39}{,-sphinx2,-sphinx3,-sphinxdev,-docs,-conda}
     codestyle
+requires =
+    setuptools >= 30.3.0
+    pip >= 19.3.1
+    tox-pypi-filter >= 0.12
 isolated_build = true
 
 [testenv]
@@ -14,11 +18,14 @@ whitelist_externals=
 deps =
     sphinx2: sphinx>=2.0,<3.0
     sphinx3: sphinx>=3.0,<4.0
+    # This is ignored as myst-parser has pinned the max version of sphinx.
     sphinxdev: git+https://github.com/sphinx-doc/sphinx
 # The following indicates which extras_require from setup.cfg will be installed
 # dev is special in that it installs everything
 extras =
-    dev
+    all
+    docs
+    tests
 setenv =
     PYTHONDONTWRITEBYTECODE = 1
 passenv =
@@ -27,6 +34,8 @@ passenv =
     NO_PROXY
     CIRCLECI
 commands =
+    # Have to do this here as myst-parser in the install step forcings it to be non-dev.
+    sphinxdev: pip install -U git+https://github.com/sphinx-doc/sphinx
     pytest
     make tests
 
@@ -47,8 +56,7 @@ commands =
     pre-commit run --color always --verbose --all-files --show-diff-on-failure
 
 # This env requires tox-conda.
-[testenv:py38-conda]
-basepython = python3.8
+[testenv:conda]
 extras =
 deps =
 conda_deps =


### PR DESCRIPTION
We have renamed master to main

Fixes https://github.com/sunpy/ablog/issues/101
We were not testing against sphinx master due to other packages pinning the max version.
I suspect it will be broken.