### PR TITLE
fix documentation typo in blog-drafts

### DIFF
--- a/docs/manual/forever-draft.rst
+++ b/docs/manual/forever-draft.rst
@@ -24,7 +24,7 @@ You can still label a post you are drafting with tags and categories, but the po
 How can you see a list of drafts?
 ---------------------------------
 
-See :ref:`blog-drafts` archive page, which can be referred to as ``:ref:blog-drafs```.
+See :ref:`blog-drafts` archive page, which can be referred to as ``:ref:`blog-drafts```.
 
 Why would you make a post draft?
 --------------------------------


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Trivial fix to a tiny typo in the example for referencing the blog-drafts page. Thanks for sharing the extension.
