### PR TITLE
Allow using a different branch when deploying

### DIFF
--- a/ablog/commands.py
+++ b/ablog/commands.py
@@ -374,6 +374,7 @@ def ablog_post(filename, title=None, **kwargs):
     help="environment variable name storing GitHub access token",
 )
 @arg("--github-ssh", dest="github_is_http", action="store_true", help="use ssh when cloning website")
+@arg("--github-branch", dest="github_branch", type=str, help="Branch to use. Default is: master.", default="master")
 @arg(
     "--push-quietly",
     dest="push_quietly",
@@ -412,6 +413,7 @@ def ablog_deploy(
     github_token=None,
     github_is_http=True,
     github_url=None,
+    github_branch=None,
     repodir=None,
     **kwargs,
 ):
@@ -423,6 +425,8 @@ def ablog_deploy(
 
     github_url = github_url or getattr(conf, "github_url", None)
     github_url += ":"
+
+    github_branch = github_branch or getattr(conf, "github_branch", "master")
 
     website = website or os.path.join(confdir, getattr(conf, "ablog_builddir", "_website"))
 
@@ -491,7 +495,7 @@ def ablog_deploy(
             push += " -q"
         if push_force:
             push += " -f"
-        push += " origin master"
+        push += f" origin {github_branch}"
         run(push, echo=True)
 
     else:

--- a/ablog/commands.py
+++ b/ablog/commands.py
@@ -374,7 +374,13 @@ def ablog_post(filename, title=None, **kwargs):
     help="environment variable name storing GitHub access token",
 )
 @arg("--github-ssh", dest="github_is_http", action="store_true", help="use ssh when cloning website")
-@arg("--github-branch", dest="github_branch", type=str, help="Branch to use. Default is: master.", default="master")
+@arg(
+    "--github-branch",
+    dest="github_branch",
+    type=str,
+    help="Branch to use. Default is: master.",
+    default="master",
+)
 @arg(
     "--push-quietly",
     dest="push_quietly",

--- a/docs/manual/ablog-commands.rst
+++ b/docs/manual/ablog-commands.rst
@@ -111,24 +111,33 @@ Running ``ablog deploy`` will push your website to GitHub::
   $ ablog deploy -h
   usage: ablog deploy [-h] [-w WEBSITE] [-p REPODIR] [-g GITHUB_PAGES]
                       [-m MESSAGE] [-f] [--push-quietly]
-                      [--github-token GITHUB_TOKEN]
+                      [--github-branch GITHUB_BRANCH] [--github-ssh]
+                      [--github-token GITHUB_TOKEN] [--github-url GITHUB_URL]
 
   Path options can be set in conf.py. Default values of paths are relative to
   conf.py.
 
-  optional arguments:
+  options:
     -h, --help            show this help message and exit
     -w WEBSITE            path for website, default is _website when
                           `ablog_website` is not set in conf.py
-    -p REPODIR            path to the location of repository to be deployed,
-                          e.g. `../username.github.io`, default is folder
-                          containing `conf.py`
+    -p REPODIR            path to the location of repository to be deployed, e.g.
+                          `../username.github.io`, default is folder containing
+                          `conf.py`
     -g GITHUB_PAGES       GitHub username for deploying to GitHub pages
     -m MESSAGE            commit message
     -f                    owerwrite last commit, i.e. `commit --amend; push -f`
     --push-quietly        be more quiet when pushing changes
+    --github-branch GITHUB_BRANCH
+                          Branch to use. Default is 'master'.
+    --github-ssh          use ssh when cloning website
     --github-token GITHUB_TOKEN
                           environment variable name storing GitHub access token
+    --github-url GITHUB_URL
+                          Custom GitHub URL. Useful when multiple accounts are
+                          configured on the same machine. Default is:
+                          git@github.com
+
 
 Create a Post
 -------------


### PR DESCRIPTION
### Description

Add an option to use a different deploy branch than master.
The default is still master, so behavior doesn't change for
current users unless they start adding the option.
