### PR TITLE
Fix tags field for myst_parser

### DIFF
--- a/ablog/post.py
+++ b/ablog/post.py
@@ -173,14 +173,14 @@ class CheckFrontMatter(SphinxTransform):
 
         # Pull the metadata for the page to check if it is a blog post
         metadata = {fn.children[0].astext(): fn.children[1].astext() for fn in docinfo.traverse(nodes.field)}
-        tags = metadata.get('tags')
+        tags = metadata.get("tags")
         if isinstance(tags, str):
             # myst_parser store front-matter field to TextNode in dict_to_fm_field_list.
             # like ["a", "b", "c"]
             # remove [] and quote
             try:
                 tags = eval(tags)
-                metadata['tags'] = ','.join(tags)
+                metadata["tags"] = ",".join(tags)
             except Exception:
                 logging.warning(f"fail to eval tags: {tags}")
         if docinfo.traverse(nodes.author):

--- a/ablog/post.py
+++ b/ablog/post.py
@@ -173,6 +173,16 @@ class CheckFrontMatter(SphinxTransform):
 
         # Pull the metadata for the page to check if it is a blog post
         metadata = {fn.children[0].astext(): fn.children[1].astext() for fn in docinfo.traverse(nodes.field)}
+        tags = metadata.get('tags')
+        if isinstance(tags, str):
+            # myst_parser store front-matter field to TextNode in dict_to_fm_field_list.
+            # like ["a", "b", "c"]
+            # remove [] and quote
+            try:
+                tags = eval(tags)
+                metadata['tags'] = ','.join(tags)
+            except Exception:
+                logging.warning(f"fail to eval tags: {tags}")
         if docinfo.traverse(nodes.author):
             metadata["author"] = list(docinfo.traverse(nodes.author))[0].astext()
         # These two fields are special-cased in docutils


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

Markdown post with tags field in front-matter has format mismatch.

```
---
tags: ["a", "b"]
---
```

Interpreted as  `["a"` and `"b"]`.

I'm fix it.

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

This is caused in 
https://github.com/executablebooks/MyST-Parser/blob/885651fc4e25dbac414c20cfe8fe3232ba4e833b/myst_parser/docutils_renderer.py#L823

And `metadata['tags']` store `["a", "b"]` text.

Thank you.
