### PR TITLE
optionally show previous / next links on post page

### DIFF
--- a/ablog/blog.py
+++ b/ablog/blog.py
@@ -119,6 +119,7 @@ CONFIG = [
     ("post_auto_excerpt", 1, True),
     ("post_redirect_refresh", 5, True),
     ("post_always_section", False, True),
+    ("post_show_prev_next", True, True),
     ("disqus_shortname", None, True),
     ("disqus_drafts", False, True),
     ("disqus_pages", False, True),

--- a/ablog/start.py
+++ b/ablog/start.py
@@ -103,6 +103,11 @@ blog_authors = {{
 # is ``False``.
 # post_always_section = False
 
+# When ``True``, links to the previous and next posts will be rendered at the 
+# bottom of the page.
+# Default is ``True``
+# post_show_prev_next = True
+
 # When ``False``, the :rst:dir:`orphan` directive is not automatically set
 # for each post. Without this directive, Sphinx will warn about posts that
 # are not explicitly referenced via another document. :rst:dir:`orphan` can

--- a/ablog/start.py
+++ b/ablog/start.py
@@ -103,7 +103,7 @@ blog_authors = {{
 # is ``False``.
 # post_always_section = False
 
-# When ``True``, links to the previous and next posts will be rendered at the 
+# When ``True``, links to the previous and next posts will be rendered at the
 # bottom of the page.
 # Default is ``True``
 # post_show_prev_next = True

--- a/ablog/templates/postnavy.html
+++ b/ablog/templates/postnavy.html
@@ -1,5 +1,5 @@
-{# prev/next are not set for drafts #} {% set post = ablog[pagename] %} {% if
-post.published %}
+{# prev/next are not set for drafts #} {% set post = ablog[pagename] %}
+{% if post.published and ablog.post_show_prev_next %}
 <div class="section">
   <span style="float: left">
     {% if post.prev %} {% if not ablog.fontawesome %}{{ gettext('Previous') }}:

--- a/docs/manual/ablog-configuration-options.rst
+++ b/docs/manual/ablog-configuration-options.rst
@@ -116,6 +116,11 @@ Post related
    This is the behavior when :rst:dir:`post` is used multiple times in a document.
    Default is ``False``.
 
+.. confval:: post_show_prev_next
+
+    When ``True``, links to the previous and next posts will be rendered at the bottom of the page.
+    Default is ``True``
+
 Blog feeds
 ----------
 


### PR DESCRIPTION
### Description

For my blog, I prefer to not show the next / previous links. This PR adds a config item to conditionally show them
