### PR TITLE
add classes to post elements

### DIFF
--- a/ablog/blog.py
+++ b/ablog/blog.py
@@ -435,8 +435,11 @@ class Post(BlogPageMixin):
             else:
                 doctree.append(deepcopy)
         else:
+            excerpt_container = nodes.container()
+            excerpt_container.attributes["classes"].append("ablog-post-excerpt")
             for node in self.excerpt:
-                doctree.append(node.deepcopy())
+                excerpt_container.append(node.deepcopy())
+            doctree.append(excerpt_container)
         app = self._blog.app
         revise_pending_xrefs(doctree, pagename)
         app.env.resolve_references(doctree, pagename, app.builder)

--- a/ablog/post.py
+++ b/ablog/post.py
@@ -507,6 +507,7 @@ def process_postlist(app, doctree, docname):
         bl.attributes["classes"].append("postlist")
         for post in posts:
             bli = nodes.list_item()
+            bli.attributes["classes"].append("ablog-post")
             bl.append(bli)
             par = nodes.paragraph()
             bli.append(par)
@@ -535,6 +536,7 @@ def process_postlist(app, doctree, docname):
                             ref["names"] = []
                             ref["internal"] = True
                             ref.append(nodes.Text(text_type(item)))
+                            par.attributes["classes"].append("ablog-post-title")
                         else:
                             ref = _missing_reference(app, item.xref, docname)
                         par.append(ref)
@@ -543,6 +545,7 @@ def process_postlist(app, doctree, docname):
             if excerpts and post.excerpt:
                 for enode in post.excerpt:
                     enode = enode.deepcopy()
+                    enode.attributes["classes"].append("ablog-post-excerpt")
                     revise_pending_xrefs(enode, docname)
                     app.env.resolve_references(enode, docname, app.builder)
                     enode.parent = bli.parent
@@ -550,6 +553,7 @@ def process_postlist(app, doctree, docname):
                 if expand:
                     ref = app.builder.get_relative_uri(docname, post.docname)
                     enode = nodes.paragraph()
+                    enode.attributes["classes"].append("ablog-post-expand")
                     refnode = nodes.reference("", "", internal=True, refuri=ref)
                     innernode = nodes.emphasis(text=expand)
                     refnode.append(innernode)

--- a/ablog/templates/collection.html
+++ b/ablog/templates/collection.html
@@ -26,8 +26,8 @@
   </div>
   {% endfor %} {% else %} {% for post in collection %}
 
-  <div class="section">
-    <h2>
+  <div class="section ablog-post">
+    <h2 class="ablog-post-title">
       <a href="{{ pathto(post.docname) }}{{ anchor(post) }}"
         >{{ post.title }}</a
       >
@@ -44,7 +44,7 @@
       {% include "postcard2.html" %}
     </ul>
     {{ post.to_html(collection.docname) }}
-    <p><a href="{{ pathto(post.docname) }}">{{ _("Read more ...") }}</a></p>
+    <p class="ablog-post-expand"><a href="{{ pathto(post.docname) }}"><em>{{ _("Read more ...") }}</em></a></p>
     <hr />
   </div>
   {% endfor %} {% endif %}

--- a/tests/test_postlist.py
+++ b/tests/test_postlist.py
@@ -19,7 +19,10 @@ def test_postlist(app, status, warning):
 
     html = read_text(app.outdir / "postlist.html")
     assert '<ul class="postlist-style-none postlist simple">' in html
-    assert '<li class="ablog-post"><p class="ablog-post-title">01 December - <a class="reference internal" href="post.html">post</a></p></li>' in html
+    assert (
+        '<li class="ablog-post"><p class="ablog-post-title">01 December - <a class="reference internal" href="post.html">post</a></p></li>'
+        in html
+    )
 
 
 @pytest.mark.sphinx("html", testroot="postlist", confoverrides={"post_date_format_short": "%Y-%m-%d"})
@@ -29,4 +32,7 @@ def test_postlist_date_format_conf(app, status, warning):
     assert app.statuscode == 0
 
     html = read_text(app.outdir / "postlist.html")
-    assert '<li class="ablog-post"><p class="ablog-post-title">2020-12-01 - <a class="reference internal" href="post.html">post</a></p></li>' in html
+    assert (
+        '<li class="ablog-post"><p class="ablog-post-title">2020-12-01 - <a class="reference internal" href="post.html">post</a></p></li>'
+        in html
+    )

--- a/tests/test_postlist.py
+++ b/tests/test_postlist.py
@@ -19,7 +19,7 @@ def test_postlist(app, status, warning):
 
     html = read_text(app.outdir / "postlist.html")
     assert '<ul class="postlist-style-none postlist simple">' in html
-    assert '<li><p>01 December - <a class="reference internal" href="post.html">post</a></p></li>' in html
+    assert '<li class="ablog-post"><p class="ablog-post-title">01 December - <a class="reference internal" href="post.html">post</a></p></li>' in html
 
 
 @pytest.mark.sphinx("html", testroot="postlist", confoverrides={"post_date_format_short": "%Y-%m-%d"})
@@ -29,4 +29,4 @@ def test_postlist_date_format_conf(app, status, warning):
     assert app.statuscode == 0
 
     html = read_text(app.outdir / "postlist.html")
-    assert '<li><p>2020-12-01 - <a class="reference internal" href="post.html">post</a></p></li>' in html
+    assert '<li class="ablog-post"><p class="ablog-post-title">2020-12-01 - <a class="reference internal" href="post.html">post</a></p></li>' in html


### PR DESCRIPTION
### Description

It's difficult to get consistent styling between `.. postlist::` and the archive pages. This PR adds classes to each part of a post to help with styling.

There was also a difference between how `.. postlist::` rendered the expand vs the archive pages. The archive now follows `.. postlist::`