### PR TITLE
Get rid of eval and fix #128

### DIFF
--- a/ablog/post.py
+++ b/ablog/post.py
@@ -179,7 +179,9 @@ class CheckFrontMatter(SphinxTransform):
             # like ["a", "b", "c"]
             # remove [] and quotes
             tags = tags.strip().lstrip("[").rstrip("]")
-            metadata["tags"] = ",".join([t.strip().lstrip('"').lstrip("'").rstrip('"').rstrip("'") for t in tags.split(',')])
+            metadata["tags"] = ",".join(
+                [t.strip().lstrip('"').lstrip("'").rstrip('"').rstrip("'") for t in tags.split(",")]
+            )
         if docinfo.traverse(nodes.author):
             metadata["author"] = list(docinfo.traverse(nodes.author))[0].astext()
         # These two fields are special-cased in docutils

--- a/ablog/post.py
+++ b/ablog/post.py
@@ -177,12 +177,9 @@ class CheckFrontMatter(SphinxTransform):
         if isinstance(tags, str):
             # myst_parser store front-matter field to TextNode in dict_to_fm_field_list.
             # like ["a", "b", "c"]
-            # remove [] and quote
-            try:
-                tags = eval(tags)
-                metadata["tags"] = ",".join(tags)
-            except Exception:
-                logging.warning(f"fail to eval tags: {tags}")
+            # remove [] and quotes
+            tags = tags.strip().lstrip("[").rstrip("]")
+            metadata["tags"] = ",".join([t.strip().lstrip('"').lstrip("'").rstrip('"').rstrip("'") for t in tags.split(',')])
         if docinfo.traverse(nodes.author):
             metadata["author"] = list(docinfo.traverse(nodes.author))[0].astext()
         # These two fields are special-cased in docutils


### PR DESCRIPTION
Just use string methods to process tags - no need for eval. This eliminates the warning and incorrect parsing of tags for markdown reported in #128.

Fixes #128 