### PR TITLE
Normalise path to posix as sphinx expects

### DIFF
--- a/ablog/__init__.py
+++ b/ablog/__init__.py
@@ -4,7 +4,6 @@ ABlog for Sphinx.
 
 import os
 from glob import glob
-
 from pathlib import PurePath
 
 from .blog import CONFIG, Blog

--- a/ablog/__init__.py
+++ b/ablog/__init__.py
@@ -5,6 +5,8 @@ ABlog for Sphinx.
 import os
 from glob import glob
 
+from pathlib import PurePath
+
 from .blog import CONFIG, Blog
 from .post import (
     CheckFrontMatter,
@@ -107,8 +109,10 @@ def config_inited(app, config):
     matched_patterns = []
     for pattern in config.blog_post_pattern:
         pattern = os.path.join(app.srcdir, pattern)
+        # make sure that blog post paths have forward slashes even on windows
         matched_patterns.extend(
-            os.path.relpath(os.path.splitext(ii)[0], app.srcdir) for ii in glob(pattern, recursive=True)
+            PurePath(ii).relative_to(app.srcdir).with_suffix("").as_posix()
+            for ii in glob(pattern, recursive=True)
         )
     app.config.matched_blog_posts = matched_patterns
 


### PR DESCRIPTION
This fixes #133 by ensuring that paths matched by `blog_post_pattern` are represented as posix-path even on windows and thus compatible with Sphinx.
