### PR TITLE
docs: Fix format of sphinx.ext.extlink for Sphinx 5.x

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,9 +117,9 @@ intersphinx_mapping = {
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
 }
 extlinks = {
-    "wiki": ("https://en.wikipedia.org/wiki/%s", ""),
-    "issue": ("https://github.com/sunpy/ablog/issues/%s", "issue "),
-    "pull": ("https://github.com/sunpy/ablog/pull/%s", "pull request "),
+    "wiki": ("https://en.wikipedia.org/wiki/%s", "%s"),
+    "issue": ("https://github.com/sunpy/ablog/issues/%s", "issue %s"),
+    "pull": ("https://github.com/sunpy/ablog/pull/%s", "pull request %s"),
 }
 exclude_patterns = ["docs/manual/.ipynb_checkpoints/*"]
 rst_epilog = """


### PR DESCRIPTION
This patch fixes the following warning:

```
WARNING: extlinks: Sphinx-6.0 will require a caption string to contain exactly one '%s' and all other '%' need to be escaped as '%%'.
WARNING: extlinks: Sphinx-6.0 will require a caption string to contain exactly one '%s' and all other '%' need to be escaped as '%%'.
WARNING: extlinks: Sphinx-6.0 will require a caption string to contain exactly one '%s' and all other '%' need to be escaped as '%%'.
```

See also: https://github.com/sphinx-doc/sphinx/pull/8898


