### PR TITLE
Improve conditional check for author metadata

### DIFF
--- a/ablog/post.py
+++ b/ablog/post.py
@@ -182,10 +182,10 @@ class CheckFrontMatter(SphinxTransform):
             metadata["tags"] = ",".join(
                 [t.strip().lstrip('"').lstrip("'").rstrip('"').rstrip("'") for t in tags.split(",")]
             )
-        if docinfo.traverse(nodes.author):
+        if list(docinfo.traverse(nodes.author)):
             metadata["author"] = list(docinfo.traverse(nodes.author))[0].astext()
         # These two fields are special-cased in docutils
-        if docinfo.traverse(nodes.date):
+        if list(docinfo.traverse(nodes.date)):
             metadata["date"] = list(docinfo.traverse(nodes.date))[0].astext()
         if "blogpost" not in metadata and self.env.docname not in self.config.matched_blog_posts:
             return None


### PR DESCRIPTION
This improves the logic of the conditional check for some page metadata, which seemed to be breaking docutils on newer versions. I think converting to a list will make the behavior more dependable.

- closes #145 