### PR TITLE
Fix typo in index.rst: spondered -> sponsored

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ ABlog is a Sphinx extension that converts any documentation or personal website 
   * :ref:`Font-Awesome integration <font-awesome>`
   * :doc:`manual/markdown`
 
-Ablog is a `SunPy spondered package <https://www.sunpy.org>`__.
+Ablog is a `SunPy sponsored package <https://www.sunpy.org>`__.
 
 .. _installation:
 


### PR DESCRIPTION
## PR Description
This is a very minor PR that just fixes a typo in docs/index.rst, changing "spondered" to the word "sponsored".

Apologies for not opening an issue first! I'm guessing y'all will want this fixed though and if not, closing a one-commit PR won't hurt me :slightly_smiling_face: 