### PR TITLE
Add spans to previous and next buttons

### DIFF
--- a/src/ablog/templates/postnavy.html
+++ b/src/ablog/templates/postnavy.html
@@ -12,7 +12,7 @@
       {% if ablog.fontawesome %}
       <i class="fa fa-arrow-circle-left"></i>
       {% endif %}
-      {{ post.prev.title }}
+      <span>{{ post.prev.title }}</span>
     </a>
     {% endif %}
   </span>
@@ -23,7 +23,7 @@
     {{ gettext('Next') }}:
     {% endif %}
     <a href="{{ pathto(post.next.docname) }}{{ anchor(post.next) }}">
-      {{ post.next.title }}
+      <span>{{ post.next.title }}</span>
       {% if ablog.fontawesome %}
       <i class="fa fa-arrow-circle-right" ></i>
       {% endif %}


### PR DESCRIPTION
This adds a span wrapper to previous and next buttons so that they can be styled with CSS more easily. (e.g. if you want to position them with `flexbox`.

There are many other places that follow this pattern but I didn't change them in order to keep this PR simpler. But for example, a structure like:

```html
<span>
    <i ... >
    Some text
</span>
```

and I think it'd be better in general to use a pattern like:

```html
<span>
    <i ... >
    <span>Some text</span>
</span>
```

This way you can apply styling to the inline text independent of the icon.