### PR TITLE
add ablog-sidebar-item to templates I missed

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,6 +89,9 @@ html_sidebars = {
         "ablog/tagcloud.html",
         "ablog/categories.html",
         "ablog/archives.html",
+        "ablog/authors.html",
+        "ablog/languages.html",
+        "ablog/locations.html",
         "searchbox.html",
     ]
 }

--- a/src/ablog/templates/ablog/languages.html
+++ b/src/ablog/templates/ablog/languages.html
@@ -1,5 +1,5 @@
 {% if ablog.language %}
-<div class="ablog__languages">
+<div class="ablog-sidebar-item ablog__languages">
 <h3>
   <a href="{{ pathto(ablog.language.path) }}">{{ gettext('Languages') }}</a>
 </h3>

--- a/src/ablog/templates/ablog/locations.html
+++ b/src/ablog/templates/ablog/locations.html
@@ -1,5 +1,5 @@
 {% if ablog.location %}
-<div class="ablog__locations">
+<div class="ablog-sidebar-item ablog__locations">
 <h3>
   <a href="{{ pathto(ablog.location.path) }}">{{ gettext('Locations') }}</a>
 </h3>

--- a/src/ablog/templates/ablog/postcard.html
+++ b/src/ablog/templates/ablog/postcard.html
@@ -1,5 +1,5 @@
 {% if pagename in ablog %}
-<div class="ablog__postcard">
+<div class="ablog-sidebar-item ablog__postcard">
 {% set fa = ablog.fontawesome %}
 {% set post = ablog[pagename] %}
 <h2>

--- a/src/ablog/templates/ablog/postcard2.html
+++ b/src/ablog/templates/ablog/postcard2.html
@@ -1,5 +1,5 @@
 {% if post.published and post.date != post.update %}
-<div class="ablog__postcard2">
+<div class="ablog-sidebar-item ablog__postcard2">
 <li id="published">
   <span>
     {% if fa %}

--- a/src/ablog/templates/languages.html
+++ b/src/ablog/templates/languages.html
@@ -1,6 +1,6 @@
 {{ warning("languages.html is an old template path, that is no longer used by ablog. Please use ablog/languages.html instead.") }}
 {% if ablog.language %}
-<div class="ablog__languages">
+<div class="ablog-sidebar-item ablog__languages">
 <h3>
   <a href="{{ pathto(ablog.language.path) }}">{{ gettext('Languages') }}</a>
 </h3>

--- a/src/ablog/templates/locations.html
+++ b/src/ablog/templates/locations.html
@@ -1,6 +1,6 @@
 {{ warning("locations.html is an old template path, that is no longer used by ablog. Please use ablog/locations.html instead.") }}
 {% if ablog.location %}
-<div class="ablog__locations">
+<div class="ablog-sidebar-item ablog__locations">
 <h3>
   <a href="{{ pathto(ablog.location.path) }}">{{ gettext('Locations') }}</a>
 </h3>

--- a/src/ablog/templates/postcard.html
+++ b/src/ablog/templates/postcard.html
@@ -1,6 +1,6 @@
 {{ warning("postcard.html is an old template path, that is no longer used by ablog. Please use ablog/postcard.html instead.") }}
 {% if pagename in ablog %}
-<div class="ablog__postcard">
+<div class="ablog-sidebar-item ablog__postcard">
 {% set fa = ablog.fontawesome %}
 {% set post = ablog[pagename] %}
 <h2>

--- a/src/ablog/templates/postcard2.html
+++ b/src/ablog/templates/postcard2.html
@@ -1,6 +1,6 @@
 {{ warning("postcard2.html is an old template path, that is no longer used by ablog. Please use ablog/postcard2.html instead.") }}
 {% if post.published and post.date != post.update %}
-<div class="ablog__postcard2">
+<div class="ablog-sidebar-item ablog__postcard2">
 <li id="published">
   <span>
     {% if fa %}

--- a/src/ablog/templates/postnavy.html
+++ b/src/ablog/templates/postnavy.html
@@ -12,7 +12,7 @@
       {% if ablog.fontawesome %}
       <i class="fa fa-arrow-circle-left"></i>
       {% endif %}
-      {{ post.prev.title }}
+      <span>{{ post.prev.title }}</span>
     </a>
     {% endif %}
   </span>
@@ -23,7 +23,7 @@
     {{ gettext('Next') }}:
     {% endif %}
     <a href="{{ pathto(post.next.docname) }}{{ anchor(post.next) }}">
-      {{ post.next.title }}
+      <span>{{ post.next.title }}</span>
       {% if ablog.fontawesome %}
       <i class="fa fa-arrow-circle-right" ></i>
       {% endif %}

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ extras =
     dev
 commands =
     # Have to do this here as myst-parser in the install step forces it to be non-dev.
-    sphinxdev: pip install -U "git+https://repo.or.cz/docutils.git#egg=docutils&subdirectory=docutils"
+    sphinxdev: pip install -U 'git+https://repo.or.cz/docutils.git#egg=docutils&subdirectory=docutils'
     sphinxdev: pip install -U git+https://github.com/sphinx-doc/sphinx
     pytest -vvv -r a --pyargs ablog
     make tests


### PR DESCRIPTION
I merged the base PR and didn't notice the original was pointing at the branch.

Original comment:

This adds a span wrapper to previous and next buttons so that they can be styled with CSS more easily. (e.g. if you want to position them with `flexbox`.

There are many other places that follow this pattern but I didn't change them in order to keep this PR simpler. But for example, a structure like:

```html
<span>
    <i ... >
    Some text
</span>
```

and I think it'd be better in general to use a pattern like:

```html
<span>
    <i ... >
    <span>Some text</span>
</span>
```

This way you can apply styling to the inline text independent of the icon.


Original PR: https://github.com/sunpy/ablog/pull/188