### PR TITLE
Clean up prev/next HTML templates

### DIFF
--- a/src/ablog/templates/ablog/postnavy.html
+++ b/src/ablog/templates/ablog/postnavy.html
@@ -2,7 +2,7 @@
 {% set post = ablog[pagename] %}
 {% if post.published and ablog.post_show_prev_next %}
 <div class="section ablog__prev-next">
-  <span>
+  <span class="ablog__prev">
     {% if post.prev %}
     {% if not ablog.fontawesome %}
     {{ gettext('Previous') }}:
@@ -11,18 +11,18 @@
       {% if ablog.fontawesome %}
       <i class="fa fa-arrow-circle-left"></i>
       {% endif %}
-      {{ post.prev.title }}
+      <span>{{ post.prev.title }}</span>
     </a>
     {% endif %}
   </span>
   <span>&nbsp;</span>
-  <span>
+  <span class="ablog__next">
     {% if post.next %}
     {% if not ablog.fontawesome %}
     {{ gettext('Next') }}:
     {% endif %}
     <a href="{{ pathto(post.next.docname) }}{{ anchor(post.next) }}">
-      {{ post.next.title }}
+      <span>{{ post.next.title }}</span>
       {% if ablog.fontawesome %}
       <i class="fa fa-arrow-circle-right" ></i>
       {% endif %}

--- a/src/ablog/templates/ablog/postnavy.html
+++ b/src/ablog/templates/ablog/postnavy.html
@@ -15,7 +15,7 @@
     </a>
     {% endif %}
   </span>
-  <span>&nbsp;</span>
+  <span class="ablog__spacer">&nbsp;</span>
   <span class="ablog__next">
     {% if post.next %}
     {% if not ablog.fontawesome %}


### PR DESCRIPTION
This copies over some of the HTML fixes that were in an old template path that hadn't been ported to the new template path. It also adds two classes to the prev/next spans so they can be selected more easily.

- closes https://github.com/sunpy/ablog/issues/194