### PR TITLE
avoid spurious warning about posts with front-matter and post directive

### DIFF
--- a/src/ablog/post.py
+++ b/src/ablog/post.py
@@ -181,8 +181,9 @@ class CheckFrontMatter(SphinxTransform):
             metadata["date"] = list(docinfo.findall(nodes.date))[0].astext()
         if "blogpost" not in metadata and self.env.docname not in self.config.matched_blog_posts:
             return None
-        if self.document.findall(PostNode):
-            logging.warning("Found blog post front-matter as well as post directive, using post directive.")
+        for node in self.document.findall(PostNode):
+            if node:
+                logging.warning("Found blog post front-matter as well as post directive, using post directive.")
         # Iterate through metadata and create a PostNode with relevant fields
         option_spec = PostDirective.option_spec
         for key, val in metadata.items():


### PR DESCRIPTION
## PR Description

Fixes https://github.com/sunpy/ablog/issues/213

The issue is caused by a wrong check on [findall](https://pydoc.dev/docutils/latest/docutils.nodes.Node.html#findall). This method returns an iterator that evaluates to true. It has to be iterated to properly check if there are any nodes in the document that match.