### PR TITLE
append posts to atom feed to keep post order from new to old

### DIFF
--- a/roots/test-build/post.rst
+++ b/roots/test-build/post.rst
@@ -1,4 +1,4 @@
-.. post:: 2020-12-01
+.. post:: 2022-12-01
    :tags: Foo Tag, BarTag
 
 Foo Post Title

--- a/src/ablog/post.py
+++ b/src/ablog/post.py
@@ -683,7 +683,7 @@ def generate_atom_feeds(app):
                 content = None
             else:
                 content = post.to_html(pagename, fulltext=feed_fulltext)
-            feed_entry = feed.add_entry()
+            feed_entry = feed.add_entry(order="append")
             feed_entry.id(post_url)
             feed_entry.link(href=post_url)
             feed_entry.author({"name": author.name for author in post.author})

--- a/src/ablog/tests/test_build.py
+++ b/src/ablog/tests/test_build.py
@@ -1,5 +1,9 @@
+from datetime import datetime
+
 import lxml
 import pytest
+
+POST_DATETIME_FMT = "%Y-%m-%dT%H:%M:%S%z"
 
 
 @pytest.mark.sphinx("html", testroot="build")  # using roots/test-build
@@ -41,6 +45,8 @@ def test_feed(app, status, warning):
     assert categories[1].attrib["term"] == "FooTag"
     content = entry.find("{http://www.w3.org/2005/Atom}content")
     assert "Foo post content." in content.text
+    update_time = entry.find("{http://www.w3.org/2005/Atom}updated")
+    first_entry_date = datetime.strptime(update_time.text, POST_DATETIME_FMT)
 
     empty_entry = entries[1]
     title = empty_entry.find("{http://www.w3.org/2005/Atom}title")
@@ -51,6 +57,11 @@ def test_feed(app, status, warning):
     assert len(categories) == 0
     content = empty_entry.find("{http://www.w3.org/2005/Atom}content")
     assert 'id="foo-empty-post"' in content.text
+    update_time = empty_entry.find("{http://www.w3.org/2005/Atom}updated")
+    second_entry_date = datetime.strptime(update_time.text, POST_DATETIME_FMT)
+
+    # check order of post based on their dates
+    assert first_entry_date > second_entry_date
 
     social_path = app.outdir / "blog/social.xml"
     assert (social_path).exists()


### PR DESCRIPTION
## PR Description

Fixes https://github.com/sunpy/ablog/issues/215

Looking at the code, it seems that there is the intention in `ablog.posts.generate_atom_feeds` to order the posts from newer to older. See:
https://github.com/sunpy/ablog/blob/af590e136e713a3cf4c5b527b78a096226abe3d1/src/ablog/post.py#L675

However, later on, posts in `sorted_posts_by_date` are added to the feed with:
https://github.com/sunpy/ablog/blob/af590e136e713a3cf4c5b527b78a096226abe3d1/src/ablog/post.py#L686

The method [add_entry](https://python-feedgen.readthedocs.io/en/latest/api.feed.html#feedgen.feed.FeedGenerator.add_entry) does prepend each post to the feed though (default behaviour), effectively reversing the order of posts a second time.

This PR explicitly sets the order of `add_entry` to not alter the post order set in `sorted_posts_by_date`.