### PR TITLE
use fully qualified URLs for images in atom feed

### DIFF
--- a/src/ablog/blog.py
+++ b/src/ablog/blog.py
@@ -301,7 +301,7 @@ def html_builder_write_doc(self, docname, doctree, img_url=False):
     Extra argument `img_url` enables conversion of `<img>` source paths to
     fully qualified URLs based on `blog_baseurl`.
     """
-    # source of images
+    # Source of images
     img_folder = "_images"
     if img_url and self.config["blog_baseurl"]:
         img_src_path = urljoin(self.config["blog_baseurl"], img_folder)

--- a/src/ablog/post.py
+++ b/src/ablog/post.py
@@ -683,7 +683,7 @@ def generate_atom_feeds(app):
             if blog.blog_feed_titles:
                 content = None
             else:
-                content = post.to_html(pagename, fulltext=feed_fulltext)
+                content = post.to_html(pagename, fulltext=feed_fulltext, img_url=True)
             feed_entry = feed.add_entry(order="append")
             feed_entry.id(post_url)
             feed_entry.link(href=post_url)


### PR DESCRIPTION
## PR Description

Fixes #19 

Some RSS readers might render the atom feed locally without any further requests to the remote website. This breaks images in the feed as they are sourced from relative links as discussed in issue #19.

This PR fixes this issue by always using a complete URL based on `blog_baseurl` as source of images in the HTML contents of the feed. Blogs without a `baseurl` will continue to use relative paths in their feeds.