### PR TITLE
docs: post_date_format_short

### DIFF
--- a/docs/manual/ablog-configuration-options.rst
+++ b/docs/manual/ablog-configuration-options.rst
@@ -91,6 +91,10 @@ Post related
 
    Date display format (default is ``'%b %d, %Y'``) for published posts that goes as input to :meth:`datetime.date.strftime`.
 
+.. confval:: post_date_format_short
+
+   Date display format in recent posts (default is ``'%d %B'``) for published posts that goes as input to :meth:`datetime.date.strftime`.
+
 .. confval:: post_auto_excerpt
 
    Number of paragraphs (default is ``1``) that will be displayed as an excerpt from the post.


### PR DESCRIPTION
Document the config option `post_date_format_short` that is used in recent posts.

## PR Description
I wanted to change the date format in the "Recent Posts" sidebar from
```
23 March - ABlog v0.11 released
```
to something like this
```
03-23 - ABlog v0.11 released
```

Looking at the source, the change was simple (in `conf.py`):
```
post_date_format_short = '%m-%d'
```

But there was no mention in the docs. 😲

This PR fixes this. 🙂

Thanks for creating and maintaining ablog! 🖖