### PR TITLE
Create demo/ before running ablog start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,4 @@ test/
 pydata-sphinx-theme/
 _build
 _version.py
+demo/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: demo rebuild tests
 
 demo:
-	rm -rf demo
+	rm -rf demo && mkdir demo
 	printf "demo\nABlog\nABlog Team\nhttps://ablog.readthedocs.io/" | ablog start
 
 rebuild:


### PR DESCRIPTION
## PR Description

ablog requires the root path to exist:

```
$ make demo
rm -rf demo
printf "demo\nABlog\nABlog Team\nhttps://ablog.readthedocs.io/" | ablog start
Welcome to the ABlog 0.11.7.dev8+g72e99ac.d20240106 quick start utility.

Please enter values for the following settings (just press Enter to accept a
default value, if one is given in brackets).

Enter the root path for your blog project (path has to exist).
> Root path for your project (path has to exist) [.]: * Please enter a valid path name.
> Root path for your project (path has to exist) [.]: * Please enter a valid path name.
> Root path for your project (path has to exist) [.]: * Please enter a valid path name.
> Root path for your project (path has to exist) [.]: * Please enter a valid path name.
> Root path for your project (path has to exist) [.]:
[Interrupted.]
```
