### PR TITLE
Make '_strip' function return as list not set.

### DIFF
--- a/src/ablog/post.py
+++ b/src/ablog/post.py
@@ -38,7 +38,7 @@ _ = get_translation(MESSAGE_CATALOG_NAME)
 
 
 def _split(a):
-    return {s.strip() for s in (a or "").split(",")}
+    return [s.strip() for s in (a or "").split(",")]
 
 
 class PostNode(nodes.Element):


### PR DESCRIPTION
## PR Description

Closes #279. This PR changes the return type of `_strip` function in `blog.py` to a `list` rather than `set`. This ensures
the order of values specified in the blog (e.g. `:author:`) is maintained on the postlist.
