### PR TITLE
Eliminate setuptools deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,8 @@
 requires = ["setuptools", "setuptools_scm", "wheel"]
 build-backend = 'setuptools.build_meta'
 
+[tool.setuptools_scm]
+
 [tool.black]
 line-length = 120
 include = '\.pyi?$'

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 ################################################################################
 # Programmatically generate some extras combos.
 ################################################################################
-extras = read_configuration("setup.cfg")["options"]["extras_require"]
+extras = read_configuration("setup.cfg")["options"]["extras_require"].copy()
 
 # Dev is everything
 extras["dev"] = list(chain(*extras.values()))


### PR DESCRIPTION
This PR eliminates the following warnings when running `python setup.py`:

first: 
```
SetuptoolsDeprecationWarning: Direct modification of value will be disallowed
!!

        ********************************************************************************
        In an effort to implement PEP 643, direct/in-place changes of static values
        that come from configuration files are deprecated.
        If you need to modify this value, please first create a copy with `dict(value)`
        and make sure conform to all relevant standards when overriding setuptools
        functionality (https://packaging.python.org/en/latest/specifications/).

        By 2025-Oct-10, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.
        ********************************************************************************

!!
```

second:
```
SetuptoolsDeprecationWarning: Direct modification of value will be disallowed

    Traceback (most recent call last):
      File "/usr/lib/python3.13/site-packages/setuptools_scm/_in
    tegration/pyproject_reading.py", line 36, in
    read_pyproject
        section = defn.get("tool", {})[tool_name]
                  ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
    KeyError: 'setuptools_scm'
```