### PR TITLE
tests: restore the working init after demostrating parallel doesnt work

### DIFF
--- a/src/ablog/tests/test_parallel.py
+++ b/src/ablog/tests/test_parallel.py
@@ -17,18 +17,21 @@ def test_not_safe_for_parallel_read(rootdir: Path, tmp_path: Path):
     bad_read_safe = '"parallel_read_safe": True'
     init_py_path = Path(__file__).parent.parent / "__init__.py"
     assert good_read_safe in init_py_path.read_text(encoding="utf-8")
-    bad_init_py = init_py_path.read_text().replace(good_read_safe, bad_read_safe)
+    original_init_py = init_py_path.read_text(encoding="utf-8")
+    bad_init_py = original_init_py.replace(good_read_safe, bad_read_safe)
     init_py_path.write_text(bad_init_py, encoding="utf-8")
+    try:
+        # liborjelinek: I wasn't able to demonstrate the issue with the `parallel` argument to the `sphinx` fixture
+        # @pytest.mark.sphinx("html", testroot="parallel", parallel=2)
+        # therefore running sphinx-build externally
+        indir = rootdir / "test-parallel"
+        run(["sphinx-build", "-b", "html", indir.as_posix(), tmp_path.as_posix(), "-j", "auto"], check=True)
 
-    # liborjelinek: I wasn't able to demonstrate the issue with the `parallel` argument to the `sphinx` fixture
-    # @pytest.mark.sphinx("html", testroot="parallel", parallel=2)
-    # therefore running sphinx-build externally
-    indir = rootdir / "test-parallel"
-    run(["sphinx-build", "-b", "html", indir.as_posix(), tmp_path.as_posix(), "-j", "auto"], check=True)
-
-    # And posts are not collected by Ablog...
-    html = (tmp_path / "postlist.html").read_text(encoding="utf-8")
-    assert "post 1" not in html
-    assert "post 2" not in html
-    assert "post 3" not in html
-    assert "post 4" not in html
+        # And posts are not collected by Ablog...
+        html = (tmp_path / "postlist.html").read_text(encoding="utf-8")
+        assert "post 1" not in html
+        assert "post 2" not in html
+        assert "post 3" not in html
+        assert "post 4" not in html
+    finally:
+        init_py_path.write_text(original_init_py, encoding="utf-8")


### PR DESCRIPTION
I **think** this test is designed so that if parallel testing starts working then this test will fail and we can enable it.

However, it was designed poorly with the init.py being overwritten by the test, this new try finally block restores the original init upon test completion.