### PR TITLE
Allow parallel execution

### DIFF
--- a/src/ablog/__init__.py
+++ b/src/ablog/__init__.py
@@ -24,6 +24,7 @@ from .post import (
     process_postlist,
     process_posts,
     purge_posts,
+    merge_posts,
 )
 from .version import version as __version__
 
@@ -150,6 +151,7 @@ def setup(app):
     app.connect("builder-inited", builder_inited)
     app.connect("doctree-read", process_posts)
     app.connect("env-purge-doc", purge_posts)
+    app.connect("env-merge-info", merge_posts)
     app.connect("doctree-resolved", process_postlist)
     app.connect("missing-reference", missing_reference)
     app.connect("html-collect-pages", generate_archive_pages)
@@ -167,6 +169,6 @@ def setup(app):
     app.add_message_catalog(MESSAGE_CATALOG_NAME, locale_dir)
     return {
         "version": __version__,
-        "parallel_read_safe": False,
+        "parallel_read_safe": True,
         "parallel_write_safe": True,
     }

--- a/src/ablog/post.py
+++ b/src/ablog/post.py
@@ -25,6 +25,7 @@ __all__ = [
     "PostListDirective",
     "CheckFrontMatter",
     "purge_posts",
+    "merge_posts",
     "process_posts",
     "process_postlist",
     "generate_archive_pages",
@@ -218,6 +219,17 @@ def purge_posts(app, env, docname):
     filename = os.path.split(docname)[1]
     env.domains["std"].data["labels"].pop(filename, None)
     env.domains["std"].data["anonlabels"].pop(filename, None)
+
+
+def merge_posts(app, env, docnames, other):
+    """
+    Merge post data from a worker environment into the main environment
+    during parallel reading.
+    """
+    if hasattr(other, "ablog_posts"):
+        if not hasattr(env, "ablog_posts"):
+            env.ablog_posts = {}
+        env.ablog_posts.update(other.ablog_posts)
 
 
 def _update_post_node(node, options, arguments):


### PR DESCRIPTION
## PR Description

Properly fix https://github.com/sunpy/ablog/issues/297.
For the time being, I'm using this monkey patch in my own conf.py:

```python
def setup(app):
    # ablog doesn't implement env-merge-info so it's not parallel-read safe.
    # Patch it here: merge worker envs into the main one, then declare it safe.
    def _merge_ablog_posts(app, env, docnames, other):
        if hasattr(other, "ablog_posts"):
            if not hasattr(env, "ablog_posts"):
                env.ablog_posts = {}
            env.ablog_posts.update(other.ablog_posts)

    app.connect("env-merge-info", _merge_ablog_posts)
    app.extensions["ablog"].parallel_read_safe = True
```

This PR would avoid that, and allow parallel execution via `python3 -m sphinx -b html --jobs=auto . _build/html`


## AI Assistance Disclosure

AI tools were used for:
- [ x ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [ ] No AI tools were used
