### PR TITLE
Sort tags in postcard2.html to avoid big diffs between builds

### DIFF
--- a/src/ablog/templates/postcard2.html
+++ b/src/ablog/templates/postcard2.html
@@ -71,7 +71,7 @@ ablog. Please use ablog/postcard2.html instead.") }}
       <i class="fa-fw fa fa-tag"></i>
       {% else %} {{ gettext('Tag') }}: {% endif %}{% endif %}
     </span>
-    {% for coll in post.tags %} {% if coll|length %}
+    {% for coll in post.tags|sort %} {% if coll|length %}
     <a href="{{ pathto(coll.docname) }}">{{ coll }}</a>
     {% if loop.index < post.tags|length %} {% endif %} {% else %} {{ coll }} {%
     if loop.index < post.tags|length %} {% endif %} {% endif %} {% endfor %}


### PR DESCRIPTION
## PR Description

Since Python randomizes set order, each commit has unnecessary differences in the order of the tag lists. This fixes it by making sure the tags are sorted the same way every time.

Fixes #332 

## AI Assistance Disclosure

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [ ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
