### PR TITLE
Run `git add` multiple times when too many files to add

### DIFF
--- a/src/ablog/commands.py
+++ b/src/ablog/commands.py
@@ -430,7 +430,9 @@ def ablog_deploy(
                     git_add.append(fnnew)
         print(f"Moved {len(git_add)} files to {github_pages}.github.io")
         os.chdir(repodir)
-        run("git add -f " + " ".join(['"{}"'.format(os.path.relpath(p)) for p in git_add]), echo=True)
+        for i in range(0, len(git_add), 1000):
+            chunk = git_add[i:i+1000]
+            run("git add -f " + " ".join(['"{}"'.format(os.path.relpath(p)) for p in chunk]), echo=True)
         if not os.path.isfile(".nojekyll"):
             open(".nojekyll", "w")
             run("git add -f .nojekyll")


### PR DESCRIPTION
When there are more than 1000 files to pass into the `git add` command, run that command multiple times, with up to 1000 files at a time, to avoid problems with too long command line.

Fixes #334


## PR Description

When there are more than 1000 files to pass into the `git add` command, run that command multiple times, with up to 1000 files at a time, to avoid problems with too long command line.

Fixes #334

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [ ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
